### PR TITLE
tomcat::instance I corrected the names

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,8 +603,8 @@ instance options:
   * **realms**                 = undef,
   * **values**                 = undef,
   * **errorReportValveClass**  = undef,
-  * **maxThreads**: tomcat max threads (default: 150)
-  * **minSpareThreads**        = '4',
+  * **max_threads**: tomcat max threads (default: 150)
+  * **min_spare_threads**        = '4',
   * **connectionTimeout**      = '20000',
   * **lockoutrealm**           = true,
   * **userdatabase**           = true,


### PR DESCRIPTION
I changed the name of the variables to the correct one, as I encountered this problem,
as we can see in instance.pp their name is different 

https://github.com/NTTCom-MS/eyp-tomcat/blob/bb58cc9ada027606122658d38f018cfe88c2b10d/manifests/instance.pp
eyp-tomcat/manifests/instance.pp

 $max_threads                           = '150',
 $min_spare_threads                     = '4',